### PR TITLE
0.1.0: Apply task fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 projectGroup=si.kamino.gradle
 projectName=lokalise
-projectVersion=0.0.9
+projectVersion=0.1.0
 
 POM_NAME=Lockalise gradle plugin
 POM_DESCRIPTION=Gradle plugin for syncing android project with lokalise.

--- a/plugin/src/main/java/si/kamino/gradle/lokalise/LokaliseBasePlugin.kt
+++ b/plugin/src/main/java/si/kamino/gradle/lokalise/LokaliseBasePlugin.kt
@@ -27,6 +27,7 @@ class LokaliseBasePlugin : Plugin<Project> {
         extractTask = project.tasks.register("lokaliseExtract", ExtractTask::class.java)
             .apply {
                 configure {
+                    it.dependsOn(downloadTask)
                     it.inputFile.set(downloadTask.flatMap { it.outputFile })
                     it.outputDirectory.set(project.layout.buildDirectory.dir("lokalise/extract"))
                 }

--- a/plugin/src/main/java/si/kamino/gradle/lokalise/LokalisePlugin.kt
+++ b/plugin/src/main/java/si/kamino/gradle/lokalise/LokalisePlugin.kt
@@ -19,9 +19,10 @@ class LokalisePlugin : Plugin<Project> {
 
         val applyTask = project.tasks.register("lokaliseApply", ApplyTask::class.java, project.rootDir)
             .apply {
-                configure {
-                    it.inputDirectory.set(basePlugin.extractTask.flatMap { it.outputDirectory })
-                    it.outputDirectory.set(File(project.projectDir, "src/main/res/"))
+                configure { applyTask ->
+                    applyTask.dependsOn(basePlugin.extractTask)
+                    applyTask.inputDirectory.set(File(basePlugin.extractTask.flatMap { it.outputDirectory }.get().asFile, "values"))
+                    applyTask.outputDirectory.set(File(project.projectDir, "src/main/res/"))
                 }
             }
 

--- a/plugin/src/main/java/si/kamino/gradle/lokalise/task/ApplyTask.kt
+++ b/plugin/src/main/java/si/kamino/gradle/lokalise/task/ApplyTask.kt
@@ -6,9 +6,11 @@ import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 import java.io.File
 import javax.inject.Inject
 
+@DisableCachingByDefault
 abstract class ApplyTask @Inject constructor(
     private val rootDir: File
 ) : DefaultTask() {

--- a/plugin/src/main/java/si/kamino/gradle/lokalise/task/DownloadTask.kt
+++ b/plugin/src/main/java/si/kamino/gradle/lokalise/task/DownloadTask.kt
@@ -10,6 +10,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 import retrofit2.HttpException
 import retrofit2.Retrofit
 import si.kamino.gradle.lokalise.api.LokaliseService
@@ -17,6 +18,7 @@ import si.kamino.gradle.lokalise.api.model.request.ExportFileRequest
 import si.kamino.gradle.lokalise.extension.LokaliseBaseExtensions
 import javax.inject.Inject
 
+@DisableCachingByDefault
 abstract class DownloadTask @Inject constructor(
     private val baseExtension: LokaliseBaseExtensions
 ) : DefaultTask() {

--- a/plugin/src/main/java/si/kamino/gradle/lokalise/task/ExtractTask.kt
+++ b/plugin/src/main/java/si/kamino/gradle/lokalise/task/ExtractTask.kt
@@ -8,8 +8,10 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 import javax.inject.Inject
 
+@DisableCachingByDefault
 abstract class ExtractTask @Inject constructor() : DefaultTask() {
 
     @get:InputFile


### PR DESCRIPTION
Bumped version to 0.1.0, as older version won't work anymore. Fixed the apply task, since the zip has a bit different structure than before. Also explicitly set task dependencies, so that tasks always run.